### PR TITLE
Add option to disable pretty print log for rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# PpSql 
-[![Build Status](https://travis-ci.org/kvokka/pp_sql.svg?branch=master)](https://travis-ci.org/kvokka/pp_sql) 
+# PpSql
+[![Build Status](https://travis-ci.org/kvokka/pp_sql.svg?branch=master)](https://travis-ci.org/kvokka/pp_sql)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/7c866da60b1b4dd78eacc379cc0e7f3b)](https://www.codacy.com/app/kvokka/pp_sql?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=kvokka/pp_sql&amp;utm_campaign=Badge_Grade)
 
-Replace standard `ActiveRecord#to_sql` method with 
+Replace standard `ActiveRecord#to_sql` method with
 [`anbt-sql-formatter`](https://github.com/sonota88/anbt-sql-formatter)
-gem for pretty SQL code output in console. Rails log will be formatted also. 
+gem for pretty SQL code output in console. Rails log will be formatted also.
 Example output:
 
 ![log](https://raw.githubusercontent.com/kvokka/pp_sql/master/screenshots/log.png)
@@ -55,13 +55,16 @@ $ bundle
 
 ## With other formatters
 
-If you are `pry` user, or use custom output formatter, use `puts` for output whitespaces, 
+If you are `pry` user, or use custom output formatter, use `puts` for output whitespaces,
 like `puts User.all.to_sql`, or use `User.all.pp_sql`.
 
 ## With Rails
 
 If you do not want to rewrite default `#to_sql` method you may specify
  `PpSql.rewrite_to_sql_method=false` in initializers.
+
+You can also disable log formatting by specifying `PpSql.add_rails_logger_formatting=false`
+in initializers.
 
  ### Add to Application record
 
@@ -76,5 +79,5 @@ end
 ```
 
 ## License
-The gem is available as open source under the terms of the 
+The gem is available as open source under the terms of the
 [MIT License](http://opensource.org/licenses/MIT).

--- a/lib/pp_sql.rb
+++ b/lib/pp_sql.rb
@@ -13,6 +13,7 @@ module PpSql
 
     def _sql_formatter
       return @_sql_formatter if defined?(@_sql_formatter) && @_sql_formatter
+
       require 'anbt-sql-formatter/formatter'
       rule = AnbtSql::Rule.new
       rule.keyword = AnbtSql::Rule::KEYWORD_UPPER_CASE
@@ -26,6 +27,7 @@ module PpSql
     def to_sql
       return self  unless ::PpSql.rewrite_to_sql_method || defined?(super)
       return super unless ::PpSql.rewrite_to_sql_method
+
       extend Formatter
       _sql_formatter.format(defined?(super) ? super.dup : dup)
     end
@@ -43,6 +45,7 @@ module PpSql
 
   module Rails5PpSqlExtraction
     # export from Rails 5 with for Rails 4.2+ versions
+
     private
 
     def colorize_payload_name(name, payload_name)

--- a/lib/pp_sql.rb
+++ b/lib/pp_sql.rb
@@ -5,8 +5,10 @@ module PpSql
   # you may switch this setting to false in initializer
   class << self
     attr_accessor :rewrite_to_sql_method
+    attr_accessor :add_rails_logger_formatting
   end
   self.rewrite_to_sql_method = true
+  self.add_rails_logger_formatting = true
 
   module Formatter
     private
@@ -72,7 +74,10 @@ module PpSql
 
   module LogSubscriberPrettyPrint
     include Formatter
+
     def sql(event)
+      return super event unless ::PpSql.add_rails_logger_formatting
+
       e = event.dup
       e.payload[:sql] = _sql_formatter.format(e.payload[:sql].dup)
       super e

--- a/pp_sql.gemspec
+++ b/pp_sql.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'reek'
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end

--- a/test/pp_sql_rails_test.rb
+++ b/test/pp_sql_rails_test.rb
@@ -24,9 +24,9 @@ end
 class User < ActiveRecord::Base; end
 
 describe PpSql do
-  after { clear_logs! }
+  after { clear_logs! && set_default_config! }
 
-  it 'load with right output' do
+  it 'load with formatted output' do
     User.create
     assert(LOGGER.string.lines.detect { |line| line =~ /INTO\n/ })
     clear_logs!
@@ -34,9 +34,21 @@ describe PpSql do
     assert_equal LOGGER.string.lines.count, 6
   end
 
+  it 'load with default output' do
+    PpSql.add_rails_logger_formatting = false
+    User.create
+    clear_logs!
+    User.first
+    assert_equal LOGGER.string.lines.count, 1
+  end
+
   private
 
   def clear_logs!
     LOGGER.string.clear
+  end
+
+  def set_default_config!
+    PpSql.add_rails_logger_formatting = true
   end
 end


### PR DESCRIPTION
I added an option to toggle log formatting in rails on or off depending on the attribute value the user sets,  just like the `rewrite_to_sql_method` attribute.
This would be helpful for users and/or teams who want to control the toggling of the log formatting with their initializers.