### PR TITLE
Make pp_sql work even if to_sql is not rewritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ like `puts User.all.to_sql`, or use `User.all.pp_sql`.
 ## With Rails
 
 If you do not want to rewrite default `#to_sql` method you may specify
- `PpSql.rewrite_to_sql_method=false` in initializers.
+ `PpSql.rewrite_to_sql_method=false` in initializers. The `#pp_sql` method will still be
+ available (for example, for use in the console).
 
 You can also disable log formatting by specifying `PpSql.add_rails_logger_formatting=false`
 in initializers.

--- a/lib/pp_sql.rb
+++ b/lib/pp_sql.rb
@@ -27,15 +27,26 @@ module PpSql
 
   module ToSqlBeautify
     def to_sql
-      return self  unless ::PpSql.rewrite_to_sql_method || defined?(super)
-      return super unless ::PpSql.rewrite_to_sql_method
-
-      extend Formatter
-      _sql_formatter.format(defined?(super) ? super.dup : dup)
+      if ::PpSql.rewrite_to_sql_method
+        format(defined?(super) ? super.dup : dup)
+      else
+        defined?(super) ? super : self
+      end
     end
 
     def pp_sql
-      puts to_sql
+      if ::PpSql.rewrite_to_sql_method
+        puts to_sql
+      else
+        puts format(to_sql.to_s)
+      end
+    end
+
+    private
+
+    def format(sql)
+      extend Formatter
+      _sql_formatter.format(sql)
     end
   end
 

--- a/test/pp_sql_test.rb
+++ b/test/pp_sql_test.rb
@@ -11,12 +11,17 @@ describe PpSql do
 
   after { PpSql.rewrite_to_sql_method = true }
 
-  it 'will parse provided sql' do
+  it 'will format provided sql by default' do
     assert_equal str.to_sql.lines.count, 4
   end
 
-  it 'throw string as is' do
+  it 'will turn off rewriting to_sql' do
     PpSql.rewrite_to_sql_method = false
     assert_equal str.to_sql.lines.count, 1
+  end
+
+  it 'will continue to format with pp_sql' do
+    PpSql.rewrite_to_sql_method = false
+    assert_equal str.pp_sql.lines.count, 4
   end
 end


### PR DESCRIPTION
@kvokka this gem is great, thanks for maintaining it! For our use case, we'd prefer not to modify to_sql everywhere, but we do want to be able to use pp_sql in the Rails console. This PR makes that possible.

I didn't have any great ideas for how to handle the case where to_sql returns something other than a sql query, so I figured maybe just calling to_s before formatting it would be ok. Open to other suggestions, though. We could check if to_sql is defined on the parent class in pp_sql, but that didn't feel great.