### PR TITLE
Fix pp_sql frozen string handling

### DIFF
--- a/lib/pp_sql.rb
+++ b/lib/pp_sql.rb
@@ -41,7 +41,7 @@ module PpSql
         puts to_sql
       else
         extend Formatter
-        puts _sql_formatter.format(to_sql.to_s)
+        puts _sql_formatter.format(to_sql.dup)
       end
     end
   end

--- a/pp_sql.gemspec
+++ b/pp_sql.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.1.0'
 
   s.add_dependency 'activerecord'
-  s.add_dependency 'anbt-sql-formatter', '~> 0.1.0', '~> 0.1.0'
+  s.add_dependency 'anbt-sql-formatter', '~> 0.1.0'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-focus'

--- a/test/pp_sql_activerecord_test.rb
+++ b/test/pp_sql_activerecord_test.rb
@@ -72,7 +72,7 @@ describe PpSql do
   it 'pp_sql formats frozen strings properly' do
     PpSql.rewrite_to_sql_method = false
     User.create
-    frozen_clause = 'id > 0'.freeze
+    frozen_clause = 'id > 0'
     out, = capture_io do
       User.all.where(frozen_clause).pp_sql
     end

--- a/test/pp_sql_activerecord_test.rb
+++ b/test/pp_sql_activerecord_test.rb
@@ -25,7 +25,7 @@ class User < ActiveRecord::Base; end
 describe PpSql do
   after { clear_logs! && set_default_config! }
 
-  it 'ActiveRecord with formatted output' do
+  it 'ActiveRecord logs with formatted output' do
     User.create
     assert(LOGGER.string.lines.detect { |line| line =~ /INTO\n/ })
     clear_logs!
@@ -33,7 +33,7 @@ describe PpSql do
     assert_equal LOGGER.string.lines.count, 6
   end
 
-  it 'ActiveRecord with default output' do
+  it 'ActiveRecord logs with default output' do
     PpSql.add_rails_logger_formatting = false
     User.create
     clear_logs!
@@ -46,12 +46,37 @@ describe PpSql do
     assert_equal User.all.to_sql, "SELECT\n    \"users\" . *\n  FROM\n    \"users\""
   end
 
+  it 'to_sql with default output' do
+    PpSql.rewrite_to_sql_method = false
+    User.create
+    assert_equal User.all.to_sql.lines.count, 1
+  end
+
+  it 'to_sql with default output but formatted logs' do
+    PpSql.rewrite_to_sql_method = false
+    User.create
+    assert_equal User.all.to_sql.lines.count, 1
+    clear_logs!
+    User.first
+    assert_equal LOGGER.string.lines.count, 6
+  end
+
   it 'pp_sql formats a relation properly' do
     User.create
     out, = capture_io do
       User.all.pp_sql
     end
     assert_equal out, "SELECT\n    \"users\" . *\n  FROM\n    \"users\"\n"
+  end
+
+  it 'pp_sql formats frozen strings properly' do
+    PpSql.rewrite_to_sql_method = false
+    User.create
+    frozen_clause = 'id > 0'.freeze
+    out, = capture_io do
+      User.all.where(frozen_clause).pp_sql
+    end
+    assert_equal out.lines.count, 8
   end
 
   private
@@ -61,6 +86,7 @@ describe PpSql do
   end
 
   def set_default_config!
+    PpSql.rewrite_to_sql_method = true
     PpSql.add_rails_logger_formatting = true
   end
 end


### PR DESCRIPTION
- When PpSql.rewrite_to_sql_method is false, the pp_sql method would fail with a frozen string. This is fixed; test case included
- Added a couple other test cases to clarify/confirm the rewrite_to_sql_method flag
- Also cleaned up a duplicate dependency version in gemspec